### PR TITLE
Add descriptions of services

### DIFF
--- a/services.html
+++ b/services.html
@@ -4,6 +4,7 @@ title: Services
 
 <h1 class="center"><i class="mdi mdi-cogs"></i> Services</h1>
 <p class="center">These are the services that we (either now or in the future) maintain and their current state in development.</p>
+<p class="center">Click on a description to find where the descriptions are sourced from!</p>
 <table>
     <tr>
         <th>Service</th>
@@ -12,18 +13,37 @@ title: Services
     <tr>
         <td> <a href="/services/wii-room">Wii Room</a> </td>
         <td class="publicly-available">Public Beta</td>
+        <td><h3><p><a href="https://nintendo.fandom.com/wiki/Wii_no_Ma">Wii no Ma(JP)
+        (Wii Room in English, or more accurately, Wii The Room) was a Japan-exclusive
+        Wii Channel operated by Wii no Ma Inc.(JP) that launched on May 1, 2009.
+        It was a video-on-demand service made exclusively for the Wii</a></p></h3></td>
     </tr>
     <tr>
         <td> <a href="/services/wii-room-go">Wii Room GO</a> </td>
         <td class="in-development">In Development</td>
+        <td><h3><p><a href="https://en.wikipedia.org/wiki/Nintendo_Network_Service_Database">A DSiWare
+        application called Dokodemo Wii no Ma, now renamed Wii Room GO, could be downloaded free
+        for Japanese users of the Nintendo DSi, and allowed them to download programs from Wii
+        no Ma on the Wii onto the DSi, and then play them back. It also allowed users to download
+        coupons onto the DSi, which can be scanned off the screen at a store.</a></p></h3></td>
     </tr>
     <tr>
         <td> <a href="/services/digicam">Digicam Print Channel</a> </td>
         <td class="publicly-available">Full Release</td>
+        <td><h3><p><a href="https://nintendo.fandom.com/wiki/Digicam_Print_Channel">The Digicam
+        Print Channel was a Wii Channel that was released only in Japan. It was created in
+        collaboration with Fujifilm. In it, players are able to upload images onto the Wii
+        via an SD Card in the same way they would with the Photo Channel. Next, they can pick
+        their favorite photos and send them to Fujifilm, who'll process them (for a price) and
+        send them to the player.</a></p></h3></td>
     </tr>
     <tr>
         <td> <a href="/services/demae">Demae Channel</a> </td>
         <td class="private-beta">Closed Beta</td>
+        <td><h3><p><a href="https://rc24.xyz/services/food.html#:~:text=The%20Demae%20Channel%20was%20a,Wii%20and%20the%20Wii%20U.">The Demae Channel
+        was a Japan-exclusive Channel that allowed you to deliver food to your home (sushi, chicken, pizza, hamburgers, etc).
+        The service it used is Demae-Can. It was later released for the Wii U, but it was discontinued on March 31, 2017
+        for both the Wii and the Wii U.</a></p></h3></td>
     </tr>
     <tr>
         <td> <a href="/services/wii-fit-check">Wii Fit Body Check Channel</a> </td>
@@ -32,5 +52,11 @@ title: Services
     <tr>
         <td> <a href="/services/tv-helper">TV no Tomo Channel</a> </td>
         <td class="in-development">In Development</td>
+        <td><h3><p><a href="https://rc24.xyz/services/television.html">The TV no Tomo Channel G Guide for Wii was
+        a Japan-exclusive Channel that let you browse a TV guide. You could also use your Wii Remote as a TV remote using it,
+        a feature that apparently would have been used on the Wii Menu but was scrapped. You could rate programs and send out
+        alerts 30 minutes before a program is starting via an email or text. Also, you used a stamp to mark programs that interest you.
+        This Channel used G-Guide from IPG. Also, HAL Laboratory, best known by making games in the Super Smash Bros. and Kirby franchise,
+        helped make this Channel.</a></p></h3></td>
     </tr>
 </table>


### PR DESCRIPTION
All descriptions of services are added, except for Wii Fit Body Check channel being it is undocumented, and this issue adds those descriptions per issue WiiLink24#17, so as to speak and/or say.

Test REPL can be viewed at https://replit.com/@6100m/SaddlebrownLoneInternalcommand#index.html