### PR TITLE
Fixed a typo in FAQ

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -84,12 +84,12 @@ title: FAQ
     
     <h2>When Demae Channel releases, how will I pay for food?</h2>
     <ul>
-        <li>The Demae Channel only supports <b>pay-on-delivery</b>, where you will have to pay in either cash or card, to the delivery driver. You cannot input your card details into the Demae Channel or Set Personal Data in any way.</li>
+        <li>The Demae Channel only supports <b>pay-on-delivery</b>, where you will have to pay in either cash or card, to the delivery driver. You cannot input your card details into the Demae Channel or set personal data in any way.</li>
     </ul>
     
     <h2>Does WiiLink save my address when using Demae Channel?</h2>
     <ul>
-        <li>No, we cannot see your address. The only time we ever recieve it is when you place an order, where it is sent straight to the provider (e.g. Dominos), not us.</li>
+        <li>No, we cannot see your address. The only time we ever receive it is when you place an order, where it is sent straight to the provider (e.g. Dominos), not us.</li>
     </ul>
     
     


### PR DESCRIPTION
Fixes a typo in the address FAQ and removed some capital letters in the pay for food point.