### PR TITLE
Fix #35 - Broken metroid prime link

### DIFF
--- a/services.md
+++ b/services.md
@@ -74,7 +74,7 @@ A myriad of services for you to best enjoy video within.
         <td class="publicly-available">Public Beta</td>
     </tr>
     <tr>
-        <td> <a href="/services/s/mprime">Metroid Prime Preview Channel</a> </td>
+        <td> <a href="#">Metroid Prime Preview Channel</a> </td>
         <td class="in-development">Planned</td>
     </tr>
     <tr>


### PR DESCRIPTION
Fixes #35

Maybe it's better to not redirect it while the page is not created