### PR TITLE
Adding more WiiConnect24 and Demae information.

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -31,13 +31,14 @@ h3, ul {
 ### Why WiiLink?
 
 - WiiLink is the only service to bring back Japanese exclusive Wii channels after they were officially shut down.
-  - We've made [Wii no Ma](/services/wii-room) and the [Digicam Print Channel](/services/digicam) functional once more.
-  - We're hard at work on the [Demae Channel](/services/demae), letting you order food directly from your Wii.
+  - We've made [Wii no Ma](/services/wii-room), the [Digicam Print Channel](/services/digicam), and the [Demae Channel](/services/demae) functional once more.
+  - We're hard at work on the [Forecast Channel](/services/w/forecast), letting you check the weather directly from your Wii.
+  - We've even brought back the [Nintendo Channel](/services/w/nintendo), allowing you to watch videos and play demos of DS games.
 - With our service, you can experience all of these once more on your Nintendo Wii - possibly for the first time.
 
 ### Why does WiiLink exist?
 
-- Without a replacement service for these Japanese and Streaming channels, they would be lost to time, never to be seen again. However, thanks to our work, future generations of players can experience these channels again!
+- Without a replacement service for these channels, they would be lost to time, never to be seen again. However, thanks to our work, future generations of players can experience these channels again!
 
 ### Is using WiiLink legal?
 
@@ -55,7 +56,7 @@ h3, ul {
   - The best time for real-time support is within our [Discord server]({{ site.discord }}), where an active community exists.
   - You can also contact us via our [Twitter](https://twitter.com/wiilink24) account!
 
-### Will the Demae Channel order real food?
+### Does the Demae Channel order real food?
 
 - Yes! Some current information:
   - Support has been developed for Domino's in Canada, and Deliveroo in Europe.
@@ -66,6 +67,7 @@ h3, ul {
 
 - You'll want to check out our [instructions on wii.guide]({{ site.guide }}) for simple, easy to follow instructions to get everything installed.
 - For video streaming channels from Striim Network, see their [installation guide]({{ site.guide_striim }})!
+- For Demae Dominos, see the [installation guide](https://wii.guide/wiilink-demae-dominos)
 
 ### How do I update a WiiLink channel?
 
@@ -88,7 +90,7 @@ h3, ul {
 
 ### Is your service a replacement for services such as RiiConnect24?
 
-- No! This service is designed to be a companion to RiiConnect24, providing exclusive Japanese and streaming services, though some channels will be able to replace them (such as Mii Contest Channel and Everybody Votes Channel)
+- No! This service is designed to be a companion to RiiConnect24, providing exclusive Japanese and streaming services, though some channels will be able to replace them (such as the Nintendo Channel and Forecast Channel)
 
 ### Why is WiiLink developing WiiConnect24?
 

--- a/index.md
+++ b/index.md
@@ -19,7 +19,9 @@ info: <i class="mdi mdi-help-circle"></i>
       <li>Watch new videos with <b>Wii Room</b>, a unique take on video on-demand.</li>
       <li>Create perfect prints with the <b>Digicam Print Channel</b> and design photo albums in a way only you do best.</li>
       <li>Watch the original Kirby anime right from your Wii with the <b>Kirby TV Channel</b>.</li>
-      <li><span class="coming-soon">Coming soon</span> Order food with the <b>Demae Channel</b> and bring tasty goodness straight to your house.</li>
+      <li>Order food with the <b>Demae Channel</b> and bring tasty goodness straight to your house.</li>
+      <li>Watch videos and download demos for DS Games with the <b>Nintendo Channel</b>.</li>
+      <li><span class="coming-soon">Coming soon</span> Check the weather from across the globe with the <b>Forecast Channel</b>.</li>
   </ul>
 </div>
 
@@ -28,7 +30,7 @@ info: <i class="mdi mdi-help-circle"></i>
 
 ## Why WiiLink?
 
-- WiiLink is the only service to bring back Japanese exclusive Wii channels after they were officially shut down. We've made [Wii no Ma](/services/wii-room) and [Digicam Print Channel](/services/digicam) functional once more, and we're hard at work on the [Demae Channel](/services/demae). With our service, you can experience all of these once more on your Nintendo Wii - possibly for the first time.
+- WiiLink is the only service to bring back Japanese exclusive Wii channels after they were officially shut down. We've made [Wii no Ma](/services/wii-room), the [Digicam Print Channel](/services/digicam) and the [Demae Channel](/services/demae) functional once more. With our service, you can experience all of these once more on your Nintendo Wii - possibly for the first time. We've even revived the [Nintendo Channel](/services/w/nintendo), and we're hard at work on the [Forecast Channel](/services/w/forecast).
 
 ## Why does WiiLink exist?
 
@@ -38,7 +40,7 @@ info: <i class="mdi mdi-help-circle"></i>
 
 - Absolutely. We develop all of our channels without copyrighted code and material, and rely solely on what is provided within the channel and public knowledge. All code is written from the ground up. You will have no legal trouble from using our service.
 
-## Will the Demae Channel order real food?
+## Does the Demae Channel order real food?
 
 - Yes!
 

--- a/services.md
+++ b/services.md
@@ -56,6 +56,10 @@ Functionality provided by WiiConnect24, revived by WiiLink.
     </tr>
     <tr>
         <td> <a href="/services/w/nintendo">Nintendo Channel</a> </td>
+        <td class="publicly-available">Full Release</td>
+    </tr>
+        <tr>
+        <td> <a href="/services/w/forecast">Forecast Channel</a> </td>
         <td class="in-development">In Development</td>
     </tr>
 </table>

--- a/services/w/forecast.html
+++ b/services/w/forecast.html
@@ -1,0 +1,14 @@
+---
+title: Forecast Channel
+layout: no-section
+---
+
+<div class="header header-logo">
+  <h2>Check the weather locally or across the world.</h2>
+</div>
+
+<div class="section">
+  <h3>Check your local weather for the next week.</h3>
+  <h3>See the weather for anywhere on the globe</h3>
+  <h3>Check the laundry index to see when you should do your laundry.</h3>
+</div>


### PR DESCRIPTION
This PR adds more information about the WiiConnect24 services, changes some channels to Full Release, and adds a link to the Demae Dominos guide in the FAQ.
Closes #37.